### PR TITLE
coredump-report: Fix OSError for ulimit command

### DIFF
--- a/glusterhealth/reports/coredump.py
+++ b/glusterhealth/reports/coredump.py
@@ -13,7 +13,7 @@ import logging
 from utils import command_output, CommandError
 
 def report_coredump(ctx):
-    cmd = ["ulimit", "-c"]
+    cmd = "ulimit -c"
     try:
         out = command_output(cmd)
         if out.strip() == "unlimited":


### PR DESCRIPTION
The ulimit needs to be executed through shell but passing cmd as list
preventing it to be executed and getting OSError. The command_output func
sets shell to True in popen call if cmd is a string object.

Signed-off-by: Prashant D <pdhange@redhat.com>