### PR TITLE
glusterd-report: Fix incorrect reporting of glusterd uptime

### DIFF
--- a/glusterhealth/reports/glusterd.py
+++ b/glusterhealth/reports/glusterd.py
@@ -18,7 +18,7 @@ def report_check_glusterd_uptime(ctx):
     cmd = "ps -C glusterd --no-header -o etimes"
     try:
         out = command_output(cmd)
-        if out.strip() < "86400":
+        if int(out.strip()) < 86400:
             ctx.warning("Glusterd uptime is less than 24 hours",
                         uptime_sec=out.strip())
         else:


### PR DESCRIPTION
We seems to have been comparing uptime in seconds to str "86400"
seconds. It should be compared with int value of glusterd uptime
to 86400 seconds (24 hr).

Signed-off-by: Prashant D <pdhange@redhat.com>