### PR TITLE
kernel-issues-report: Check gluster processes were blocked for 120 sec

### DIFF
--- a/glusterhealth/reports/kernel_issues.py
+++ b/glusterhealth/reports/kernel_issues.py
@@ -1,5 +1,7 @@
 import logging
 
+gluster_binaries = {'glusterfsd','glusterd','glusterfs'}
+
 num_panic = 0
 num_locks = 0
 
@@ -16,5 +18,16 @@ def report_kernel_issues(ctx):
     if num_panic > 0:
         ctx.error("Kernel Panic", num_panic=num_panic)
 
-
-
+def report_gluster_hung_task(ctx):
+	gldict = dict.fromkeys(gluster_binaries, 0)
+	with open("/var/log/messages","r") as fp:
+		for line in fp:
+			if "blocked for more than 120 seconds" in line:
+				task_hung_str = line.strip().split('INFO')[1]
+				task_hung = task_hung_str.strip().split(':')[1]
+				task_name = task_hung.strip().split(' ')[1]
+				if task_name in gluster_binaries:
+					gldict[task_name] = gldict[task_name] + 1
+	
+	for task_name in gldict:
+		ctx.error("Gluster process was hung/blocked for more than 120 seconds", process=task_name, times=gldict[task_name])

--- a/glusterhealth/reports/kernel_issues.py
+++ b/glusterhealth/reports/kernel_issues.py
@@ -29,5 +29,7 @@ def report_gluster_hung_task(ctx):
 				if task_name in gluster_binaries:
 					gldict[task_name] = gldict[task_name] + 1
 	
-	for task_name in gldict:
-		ctx.error("Gluster process was hung/blocked for more than 120 seconds", process=task_name, times=gldict[task_name])
+	for task_name, times in gldict.iteritems():
+		if times > 0:
+			ctx.error("Gluster process was hung/blocked for more than 120 seconds", \
+						 process=task_name, times=times)


### PR DESCRIPTION

The gluster processes might hung/blocked due to storage driver, n/w driver
or kernel issue.

Signed-off-by: Prashant D <pdhange@gmail.com>