### PR TITLE
process-status-report: Fix self-heal daemon CPU consumption reporting

### DIFF
--- a/glusterhealth/reports/process_status.sh
+++ b/glusterhealth/reports/process_status.sh
@@ -2,16 +2,11 @@
 
 good=80
 
-pid=`gluster v status test | awk '/Self-heal/ {print $NF}'`
-value=`ps -p $pid -o %cpu | grep -v CPU` | cut -d'.' -f1 
+pid=`gluster v status| grep localhost|awk '/Self-heal/ {print $NF}'|uniq`
+value=`ps -p $pid -o %cpu | grep -v CPU | cut -d'.' -f1` 
 echo $value
 
 if (( $(echo "$value $good" | awk '{print ($1 > $2)}') ))
 then 
     echo "High CPU usage by Self-heal $value"
 fi
-
-
-
-
-


### PR DESCRIPTION
We seems to be using dummy volume test in shell script and also
there will be multiple volumes on gluster node. There will be
single self-heal daemon running on node, so need to check
CPU consumption of localhost self-heal daemon.

Signed-off-by: Prashant D <pdhange@redhat.com>