### PR TITLE
problem: op_version and max_op_version is not displaying

### DIFF
--- a/glusterhealth/reports/glusterd-op-version.py
+++ b/glusterhealth/reports/glusterd-op-version.py
@@ -20,8 +20,8 @@ def report_check_glusterd_op_version(ctx):
     try:
         out1 = command_output(cmd1)
         out2 = command_output(cmd2)
-        version1 = out1.split("\n")[-1].split(" ")[-1].strip()
-        version2 = out2.split("\n")[-1].split(" ")[-1].strip()
+        version1 = out1.split()[-1]
+        version2 = out2.split()[-1]
         if version1 != version2:
             ctx.warning("op-version is not up to date")
         else:


### PR DESCRIPTION
Description:
When op_version and max_op_version is same, in the logs it is not
displaying the version, it just displaying the blank space.

eg o/p:

[     OK] no gfid mismatch
[     OK] op-version is up to date  op_version=  max_op_version=
