### PR TITLE
Adding playbook to install gluster-health-report

### DIFF
--- a/ansible/install-gluster-health-report.yaml
+++ b/ansible/install-gluster-health-report.yaml
@@ -4,15 +4,7 @@
   remote_user: root
 
   tasks:
-  - name: Downloading pip2 from bootstrap.pypa
-    get_url:
-      url: https://bootstrap.pypa.io/get-pip.py
-      dest: /root/get-pip.py
-
-  - name: Installing pip2
-    command: "python get-pip.py"
-
-  - name: Installing gluster-health-report using pip
-    pip:
+  - name: Installing gluster-health-report using easy_install
+    easy_install:
       name: gluster-health-report
       state: latest

--- a/ansible/install-gluster-health-report.yaml
+++ b/ansible/install-gluster-health-report.yaml
@@ -1,0 +1,18 @@
+---
+- hosts: gluster_servers
+  gather_facts: no
+  remote_user: root
+
+  tasks:
+  - name: Downloading pip2 from bootstrap.pypa
+    get_url:
+      url: https://bootstrap.pypa.io/get-pip.py
+      dest: /root/get-pip.py
+
+  - name: Installing pip2
+    command: "python get-pip.py"
+
+  - name: Installing gluster-health-report using pip
+    pip:
+      name: gluster-health-report
+      state: latest


### PR DESCRIPTION
While installing gluster-health-report on a large
number of nodes, I felt it would be easy if we have
an ansible playbook which can be called independently
or through other ansible playbook.
Signed-off-by: kshithijiyer <kshithij.ki@gmail.com>