### PR TITLE
modify coredump.py: subprocess returns binary string

### DIFF
--- a/glusterhealth/reports/coredump.py
+++ b/glusterhealth/reports/coredump.py
@@ -18,7 +18,7 @@ def report_coredump(ctx):
     cmd = "ulimit -c"
     try:
         out = command_output(cmd)
-        if out.strip() == "unlimited":
+        if out.strip() == b"unlimited":
             ctx.ok("The maximum size of core files created is set to "
                    "unlimted.")
         else:

--- a/glusterhealth/reports/firewall-check.py
+++ b/glusterhealth/reports/firewall-check.py
@@ -19,7 +19,9 @@ def report_check_firewall_ports(ctx):
     cmd1 = "netstat -npl | grep -n /glusterfsd | grep tcp"
     try:
         out = command_output(cmd)
+        out = out.decode('utf-8', 'replace') if out else None
         out1 = command_output(cmd1)
+        out1 = out1.decode('utf-8', 'replace') if out1 else None
 
         if out:
             ctx.ok("Ports open for glusterd:\n" + out)


### PR DESCRIPTION
Signed-off-by: root <greatdolphin@gmail.com>

There was a bug in ./glusterhealth/reports/coredump.py:
line 21:     subprocess returns bytes rather than a string.